### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=Multi_OLED
+version=0.0.0
+author=Larry Bank
+maintainer=Larry Bank
+sentence=Easily control multiple SH1106/SSD1306 OLED displays using a minimum of GPIO lines.
+paragraph=Supports 64x32, 128x32, 128x64 and 132x64 (SH1106) display sizes.
+category=Display
+url=https://github.com/bitbank2/Multi_OLED
+architectures=*
+includes=Multi_OLED.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

This file is also required for inclusion in the [Arduino Library Manager index](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata